### PR TITLE
Introduce Kahpp Gradle Plugin as module

### DIFF
--- a/kahpp-gradle-plugin/build.gradle
+++ b/kahpp-gradle-plugin/build.gradle
@@ -1,0 +1,56 @@
+plugins {
+    id 'java-gradle-plugin'
+    id 'maven-publish'
+    id 'groovy'
+    id 'java'
+}
+
+gradlePlugin {
+    plugins {
+        kahpp {
+            id = "dev.vox.platform.kahpp"
+            implementationClass = "dev.vox.platform.kahpp.gradle.plugin.KaHPPGradlePlugin"
+        }
+    }
+}
+
+ext {
+    springVersion = '2.6.4'
+}
+
+dependencies {
+    api "org.yaml:snakeyaml:1.29"
+    api "org.assertj:assertj-core:3.21.0"
+    api "org.springframework.boot:spring-boot-gradle-plugin:${springVersion}"
+    api("io.spring.gradle:dependency-management-plugin:1.0.11.RELEASE")
+    compileOnly localGroovy()
+    testImplementation gradleTestKit()
+    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.1'
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.1'
+}
+
+project.dependencies.add( "implementation", project.dependencies.create("org.springframework.boot:spring-boot-starter-validation:${springVersion}"))
+project.dependencies.add( "implementation", project.dependencies.create("org.springframework.kafka:spring-kafka-test:${springVersion}"))
+project.dependencies.add( "implementation", project.dependencies.create("org.springframework.boot:spring-boot-starter-test:${springVersion}"))
+
+spotless {
+    groovyGradle {
+        greclipse()
+        indentWithSpaces()
+    }
+    groovy {
+        greclipse()
+        indentWithSpaces()
+    }
+}
+
+jacoco {
+    jacocoTestCoverageVerification {
+        violationRules {
+            enabled = false
+        }
+    }
+}
+
+spotbugsMain.enabled = false
+spotbugsTest.enabled = false

--- a/kahpp-gradle-plugin/src/main/groovy/dev/vox/platform/kahpp/gradle/plugin/KaHPPCopyConfigFromHelm.groovy
+++ b/kahpp-gradle-plugin/src/main/groovy/dev/vox/platform/kahpp/gradle/plugin/KaHPPCopyConfigFromHelm.groovy
@@ -1,0 +1,31 @@
+package dev.vox.platform.kahpp.gradle.plugin
+
+import org.gradle.api.file.FileType
+import org.gradle.api.tasks.TaskAction
+import org.gradle.work.ChangeType
+import org.gradle.work.InputChanges
+
+abstract class KaHPPCopyConfigFromHelm extends KaHPPHelmYamlAbstractTask {
+    @TaskAction
+    void execute(InputChanges inputChanges) {
+        inputChanges.getFileChanges(helmDir).each { change ->
+            if (change.fileType == FileType.DIRECTORY) return
+                if (!change.file.name.matches(~/.*.y*ml/)) return
+                if (change.file.parentFile.name != getEnv()) return
+                if (change.changeType == ChangeType.REMOVED) return
+
+                File helmValuesFile = new File(change.normalizedPath)
+            KaHPPInstance instance = getInstance(helmValuesFile)
+
+            def instanceName = instance.getCanonicalName()
+            println "Found KaHPP configuration: '${instanceName}'"
+            def instanceOutputDir = new File(outputDir.get().toString(), instanceName)
+            if (!instanceOutputDir.exists()) {
+                println "Creating directory: ${instanceOutputDir}"
+                instanceOutputDir.mkdir()
+            }
+            FileWriter writer = new FileWriter(new File(instanceOutputDir, "kahpp-instance.yaml"))
+            yaml.dump(instance, writer)
+        }
+    }
+}

--- a/kahpp-gradle-plugin/src/main/groovy/dev/vox/platform/kahpp/gradle/plugin/KaHPPDetectHelmToTestDrift.groovy
+++ b/kahpp-gradle-plugin/src/main/groovy/dev/vox/platform/kahpp/gradle/plugin/KaHPPDetectHelmToTestDrift.groovy
@@ -1,0 +1,41 @@
+package dev.vox.platform.kahpp.gradle.plugin
+
+import org.gradle.api.file.FileType
+import org.gradle.api.tasks.TaskAction
+import org.gradle.work.ChangeType
+import org.gradle.work.InputChanges
+
+import static org.assertj.core.api.Assertions.assertThat
+
+abstract class KaHPPDetectHelmToTestDrift extends KaHPPHelmYamlAbstractTask {
+    @TaskAction
+    void execute(InputChanges inputChanges) {
+        inputChanges.getFileChanges(helmDir).each { change ->
+            if (change.fileType == FileType.DIRECTORY) return
+                if (!change.file.name.matches(~/.*.y*ml/)) return
+                if (change.file.parentFile.name != getEnv()) return
+                if (change.changeType == ChangeType.REMOVED) return
+
+                File helmValuesFile = new File(change.normalizedPath)
+
+            KaHPPInstance expectedInstance = getInstance(helmValuesFile)
+            String instanceName = expectedInstance.getCanonicalName()
+            println "Found KaHPP configuration: '${instanceName}'"
+            File instanceOutputDir = new File(outputDir.get().toString(), instanceName)
+
+            assertThat(instanceOutputDir)
+                    .as("Instance '%s' was not tested", instanceName)
+                    .isDirectory()
+
+            File actualInstanceFile = new File(instanceOutputDir, "kahpp-instance.yaml")
+            assertThat(actualInstanceFile)
+                    .as("Instance '%s' was not tested", instanceName)
+                    .isFile()
+
+            KaHPPInstance actualInstance = yaml.loadAs(actualInstanceFile.newDataInputStream(), KaHPPInstance.class)
+            assertThat(yaml.dump(actualInstance))
+                    .as("Instance '%s' has drifted from Helm", instanceName)
+                    .isEqualTo(yaml.dump(expectedInstance))
+        }
+    }
+}

--- a/kahpp-gradle-plugin/src/main/groovy/dev/vox/platform/kahpp/gradle/plugin/KaHPPGradlePlugin.groovy
+++ b/kahpp-gradle-plugin/src/main/groovy/dev/vox/platform/kahpp/gradle/plugin/KaHPPGradlePlugin.groovy
@@ -1,0 +1,83 @@
+package dev.vox.platform.kahpp.gradle.plugin
+
+import io.spring.gradle.dependencymanagement.DependencyManagementPlugin
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.plugins.JavaLibraryPlugin
+import org.gradle.api.tasks.testing.Test
+import org.springframework.boot.gradle.plugin.SpringBootPlugin
+
+class KaHPPGradlePlugin implements Plugin<Project> {
+
+    @Override
+    void apply(Project project) {
+        project.pluginManager.apply(JavaLibraryPlugin)
+        project.pluginManager.apply(SpringBootPlugin)
+        project.pluginManager.apply(DependencyManagementPlugin)
+
+        project.tasks.getByName("bootJar").configure {
+            mainClass = "dev.vox.platform.kahpp.Application"
+        }
+
+        project.task("detectHelmToTestDrift", type: KaHPPDetectHelmToTestDrift) {
+            setGroup("kahpp")
+
+            helmDir.set(new File("${project.projectDir}/helm/values"))
+            outputDir.set(new File("${project.projectDir}/src/test/resources/functional"))
+        }
+
+        project.task("copyConfigFromHelm", type: KaHPPCopyConfigFromHelm) {
+            setGroup("kahpp")
+
+            helmDir.set(new File("${project.projectDir}/helm/values"))
+            outputDir.set(new File("${project.projectDir}/src/test/resources/functional"))
+        }
+
+        def generateTestTasks = project.task("generateTestTasks") {
+            setGroup("kahpp")
+            def instancesDirs = []
+            def functionalTestsDir = new File("${project.projectDir}/src/test/resources/functional")
+
+            if (functionalTestsDir.isDirectory()) {
+                functionalTestsDir
+                        .eachDir {
+                            instancesDirs.push(it.canonicalFile.name)
+                            inputs.dir(it)
+                        }
+            }
+
+            instancesDirs.each { kahppInstance ->
+                String taskName = "test-${kahppInstance}"
+                project.task(taskName, type: KaHPPTest) {
+                    setGroup("kahpp")
+                    setDescription("Runs functional KaHPP tests for ${taskName}")
+                    File buildDir = new File("${project.buildDir}/kahpp/${kahppInstance}")
+                    doFirst {
+                        println "Running tests for KaHPP instance: ${kahppInstance}"
+                        systemProperty("kahpp-test.instance", kahppInstance)
+                        systemProperty("kahpp-test.build-dir", buildDir.absolutePath)
+                        new File("${buildDir}/pacts").mkdirs()
+                    }
+                    useJUnitPlatform()
+                    testClassesDirs = project.sourceSets.test.output.classesDirs
+                    classpath = project.sourceSets.test.runtimeClasspath
+                    outputs.upToDateWhen { false }
+                    // Ensures that even when changing the kahpp files, tests run
+                    mustRunAfter project.getTasksByName("test", false).find()
+                    //                    filter {
+                    //                        includeTestsMatching "dev.vox.platform.kahpp.instance.*"
+                    //                    }
+                }
+            }
+        }
+
+        def testAll = project.task("testAll", type: Test) {
+            setGroup("kahpp")
+            project.tasks.withType(KaHPPTest).findAll().each { testTask ->
+                it.finalizedBy(testTask)
+            }
+        }
+
+        testAll.dependsOn(generateTestTasks)
+    }
+}

--- a/kahpp-gradle-plugin/src/main/groovy/dev/vox/platform/kahpp/gradle/plugin/KaHPPHelmYamlAbstractTask.groovy
+++ b/kahpp-gradle-plugin/src/main/groovy/dev/vox/platform/kahpp/gradle/plugin/KaHPPHelmYamlAbstractTask.groovy
@@ -1,0 +1,80 @@
+package dev.vox.platform.kahpp.gradle.plugin
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputDirectory
+import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.options.Option
+import org.gradle.work.Incremental
+import org.yaml.snakeyaml.DumperOptions
+import org.yaml.snakeyaml.Yaml
+
+abstract class KaHPPHelmYamlAbstractTask extends DefaultTask {
+    private transient String env = "staging"
+
+    protected final transient Yaml yaml;
+
+    KaHPPHelmYamlAbstractTask() {
+        DumperOptions options = new DumperOptions()
+        options.setIndent(2)
+        options.setWidth(80)
+        options.setSplitLines(false)
+        options.setExplicitStart(false)
+        options.setDefaultScalarStyle(DumperOptions.ScalarStyle.PLAIN)
+        options.setDefaultFlowStyle(DumperOptions.FlowStyle.BLOCK)
+        yaml = new Yaml(options)
+    }
+
+    @Incremental
+    @InputDirectory
+    abstract DirectoryProperty getHelmDir()
+
+    @OutputDirectory
+    abstract DirectoryProperty getOutputDir()
+
+    @Input
+    String getEnv() {
+        return this.env
+    }
+
+    @Option(option = "env", description = "The Helm environment to copy configuration files from")
+    void setEnv(String env) {
+        this.env = env
+    }
+
+    protected List<KaHPPInstance> getInstances(File helmValuesFile) {
+        Map<String, Object> helmValues = yaml.load(helmValuesFile.newDataInputStream())
+        Map<String, Map<String, Object>> kahpp = helmValues.get("kahpp")
+        List<Map<String, Object>> instances = kahpp.get("instances")
+
+        List<KaHPPInstance> kahppInstances = new ArrayList<>()
+
+        instances.forEach {
+            Map<String, Object> streamsConfig = it.get("streamsConfig")
+            streamsConfig.put("bootstrapServers", List.of("kafka:9092"))
+            kahppInstances.push(new KaHPPInstance(Map.of("kahpp", it)))
+        }
+
+        return kahppInstances.asUnmodifiable()
+    }
+
+    protected KaHPPInstance getInstance(File helmValuesFile) {
+        Map<String, Object> helmValues = yaml.load(helmValuesFile.newDataInputStream())
+        Map<String, Object> instance = helmValues.get("instance")
+        Map<String, Object> streamsConfig = instance.get("streamsConfig")
+        streamsConfig.put("bootstrapServers", List.of("kafka:9092"))
+        return new KaHPPInstance(Map.of("kahpp", instance));
+    }
+}
+
+class KaHPPInstance extends HashMap<String, Object> {
+    KaHPPInstance(Map<String, Object> m) {
+        super(m);
+    }
+
+    String getCanonicalName() {
+        Map<String, Object> kahpp = this.get("kahpp")
+        return kahpp.get("group").toString() + "-" + kahpp.get("name").toString()
+    }
+}

--- a/kahpp-gradle-plugin/src/main/groovy/dev/vox/platform/kahpp/gradle/plugin/KaHPPTest.groovy
+++ b/kahpp-gradle-plugin/src/main/groovy/dev/vox/platform/kahpp/gradle/plugin/KaHPPTest.groovy
@@ -1,0 +1,5 @@
+package dev.vox.platform.kahpp.gradle.plugin
+
+import org.gradle.api.tasks.testing.Test
+
+abstract class KaHPPTest extends Test {}

--- a/kahpp-gradle-plugin/src/test/java/dev/vox/platform/kahpp/gradle/plugin/functional/BasicTest.java
+++ b/kahpp-gradle-plugin/src/test/java/dev/vox/platform/kahpp/gradle/plugin/functional/BasicTest.java
@@ -1,0 +1,26 @@
+package dev.vox.platform.kahpp.gradle.plugin.functional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.net.URL;
+import org.gradle.testkit.runner.BuildResult;
+import org.gradle.testkit.runner.GradleRunner;
+import org.junit.jupiter.api.Test;
+
+class BasicTest {
+  private final URL testProjectUrl = ClassLoader.getSystemResource("functional/basic");
+
+  @Test
+  public void hasAllTasks() {
+    BuildResult result =
+        GradleRunner.create()
+            .withPluginClasspath()
+            .withProjectDir(new File(testProjectUrl.getFile()))
+            .withArguments("tasks", "--group=kahpp")
+            .build();
+
+    assertThat(result.getOutput())
+        .contains("copyConfigFromHelm", "detectHelmToTestDrift", "generateTestTasks", "testAll");
+  }
+}

--- a/kahpp-gradle-plugin/src/test/java/dev/vox/platform/kahpp/gradle/plugin/functional/HelmCopyTest.java
+++ b/kahpp-gradle-plugin/src/test/java/dev/vox/platform/kahpp/gradle/plugin/functional/HelmCopyTest.java
@@ -1,0 +1,77 @@
+package dev.vox.platform.kahpp.gradle.plugin.functional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Comparator;
+import org.gradle.testkit.runner.BuildResult;
+import org.gradle.testkit.runner.BuildTask;
+import org.gradle.testkit.runner.GradleRunner;
+import org.gradle.testkit.runner.TaskOutcome;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class HelmCopyTest {
+  private final transient File testProjectDir =
+      new File(ClassLoader.getSystemResource("functional/helm-copy").getFile());
+  private final transient File resourcesOutputDir =
+      new File(testProjectDir, "src/test/resources/functional");
+
+  @BeforeEach
+  void setUp() throws IOException {
+    cleanUpOutputFiles();
+  }
+
+  private void cleanUpOutputFiles() throws IOException {
+    if (!resourcesOutputDir.exists()) return;
+    Path src = resourcesOutputDir.toPath().getParent().getParent().getParent();
+    Files.walk(src).sorted(Comparator.reverseOrder()).map(Path::toFile).forEach(File::delete);
+  }
+
+  @Test
+  public void canDetectDriftFromHelmToTestsState() {
+    BuildResult result =
+        GradleRunner.create()
+            .withPluginClasspath()
+            .withProjectDir(testProjectDir)
+            .withArguments("detectHelmToTestDrift")
+            .buildAndFail();
+
+    BuildTask taskResult = result.task(":detectHelmToTestDrift");
+    assertThat(taskResult).isNotNull();
+    assertThat(taskResult.getOutcome()).isEqualTo(TaskOutcome.FAILED);
+
+    assertThat(result.getOutput())
+        .contains(
+            "Found KaHPP configuration: 'kahpp-plugin-test-copying-config-from-helm'",
+            "Instance 'kahpp-plugin-test-copying-config-from-helm' was not tested");
+  }
+
+  @Test
+  public void canDetectAndCopyHelmKaHPPConfiguration() {
+    BuildResult result =
+        GradleRunner.create()
+            .withPluginClasspath()
+            .withProjectDir(testProjectDir)
+            .withArguments("--rerun-tasks", "copyConfigFromHelm")
+            .build();
+
+    BuildTask taskResult = result.task(":copyConfigFromHelm");
+    assertThat(taskResult).isNotNull();
+    assertThat(taskResult.getOutcome()).isEqualTo(TaskOutcome.SUCCESS);
+
+    String instanceName = "kahpp-plugin-test-copying-config-from-helm";
+
+    assertThat(result.getOutput())
+        .contains("Found KaHPP configuration: '" + instanceName + "'", "Creating directory:");
+
+    File outputDir = new File(resourcesOutputDir, instanceName);
+    assertThat(outputDir).exists();
+    assertThat(outputDir).isDirectory();
+
+    assertThat(new File(outputDir, "kahpp-instance.yaml")).isFile();
+  }
+}

--- a/kahpp-gradle-plugin/src/test/resources/functional/basic/build.gradle
+++ b/kahpp-gradle-plugin/src/test/resources/functional/basic/build.gradle
@@ -1,0 +1,4 @@
+
+plugins {
+    id 'dev.vox.platform.kahpp'
+}

--- a/kahpp-gradle-plugin/src/test/resources/functional/basic/settings.gradle
+++ b/kahpp-gradle-plugin/src/test/resources/functional/basic/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'functional-basic'

--- a/kahpp-gradle-plugin/src/test/resources/functional/helm-copy/build.gradle
+++ b/kahpp-gradle-plugin/src/test/resources/functional/helm-copy/build.gradle
@@ -1,0 +1,5 @@
+
+plugins {
+    id 'base'
+    id 'dev.vox.platform.kahpp'
+}

--- a/kahpp-gradle-plugin/src/test/resources/functional/helm-copy/helm/values/test/staging/values.yaml
+++ b/kahpp-gradle-plugin/src/test/resources/functional/helm-copy/helm/values/test/staging/values.yaml
@@ -1,0 +1,14 @@
+instance:
+  group: kahpp-plugin
+  name: test-copying-config-from-helm
+  topics:
+    source: my-source-topic
+    sink: my-sink-topic
+  streamsConfig:
+    bootstrapServers:
+      - my-staging-cluster:9092
+  steps:
+    - name: produceRecordToSinkTopic
+      type: dev.vox.platform.kahpp.configuration.topic.ProduceToTopic
+      config:
+        topic: sink

--- a/kahpp-gradle-plugin/src/test/resources/functional/helm-copy/settings.gradle
+++ b/kahpp-gradle-plugin/src/test/resources/functional/helm-copy/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'functional-helm-copy'

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,4 @@
 rootProject.name = 'kahpp-oss'
 include 'kahpp-spring-autoconfigure'
 include 'kahpp-spring-starter'
+include 'kahpp-gradle-plugin'


### PR DESCRIPTION
This is in substance the porting of the Kahpp Plugin.
It works identically to the old one but now it uses the Kahpp Starter and adds a few Spring dependencies that permit a project to run a Kahpp Instance easily with Spring.

Reviewers: @GetFeedback/platform-java
