### PR TITLE
Exclude test components from prod profile

### DIFF
--- a/kahpp-spring-autoconfigure/src/main/java/dev/vox/platform/kahpp/test/instance/InstanceTest.java
+++ b/kahpp-spring-autoconfigure/src/main/java/dev/vox/platform/kahpp/test/instance/InstanceTest.java
@@ -50,6 +50,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Profile;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit.jupiter.EnabledIf;
 
@@ -58,6 +59,7 @@ import org.springframework.test.context.junit.jupiter.EnabledIf;
  * unit tests as they're suppose to have a real KaHPP configuration file. See the available
  * tests/tasks by running: `./gradlew tasks --group=kahpp`
  */
+@Profile("test")
 @SpringBootTest(
     classes = {
       Serdes.class,

--- a/kahpp-spring-autoconfigure/src/main/java/dev/vox/platform/kahpp/test/instance/InstanceTestConfiguration.java
+++ b/kahpp-spring-autoconfigure/src/main/java/dev/vox/platform/kahpp/test/instance/InstanceTestConfiguration.java
@@ -23,7 +23,9 @@ import java.time.ZoneId;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
+import org.springframework.context.annotation.Profile;
 
+@Profile("test")
 @Configuration
 public class InstanceTestConfiguration {
   public static final Instant CLOCK_FROZEN_INSTANT = Instant.parse("2020-08-02T10:00:00Z");

--- a/kahpp-spring-autoconfigure/src/main/java/dev/vox/platform/kahpp/test/instance/KahppSpringTest.java
+++ b/kahpp-spring-autoconfigure/src/main/java/dev/vox/platform/kahpp/test/instance/KahppSpringTest.java
@@ -1,7 +1,9 @@
 package dev.vox.platform.kahpp.test.instance;
 
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.context.annotation.Profile;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
+@Profile("test")
 @ExtendWith(SpringExtension.class)
 public @interface KahppSpringTest {}

--- a/kahpp-spring-autoconfigure/src/main/java/dev/vox/platform/kahpp/test/instance/KahppSpringTestConfiguration.java
+++ b/kahpp-spring-autoconfigure/src/main/java/dev/vox/platform/kahpp/test/instance/KahppSpringTestConfiguration.java
@@ -4,7 +4,9 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Profile;
 
+@Profile("test")
 @TestConfiguration
 public class KahppSpringTestConfiguration {
   @Bean

--- a/kahpp-spring-autoconfigure/src/main/java/dev/vox/platform/kahpp/test/instance/pact/PactConfigurationToHttpCallStep.java
+++ b/kahpp-spring-autoconfigure/src/main/java/dev/vox/platform/kahpp/test/instance/pact/PactConfigurationToHttpCallStep.java
@@ -7,9 +7,11 @@ import dev.vox.platform.kahpp.step.ConfigurationToStep;
 import dev.vox.platform.kahpp.step.StepConfiguration;
 import dev.vox.platform.kahpp.streams.Instance;
 import java.util.HashMap;
+import org.springframework.context.annotation.Profile;
 import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
 
+@Profile("test")
 @Component
 @Order(500) // Ensure we can modify the Step and inject the Pact Server URI
 public class PactConfigurationToHttpCallStep implements ConfigurationToStep<HttpCall> {

--- a/kahpp-spring-autoconfigure/src/main/java/dev/vox/platform/kahpp/test/instance/pact/PactMockServiceRegistry.java
+++ b/kahpp-spring-autoconfigure/src/main/java/dev/vox/platform/kahpp/test/instance/pact/PactMockServiceRegistry.java
@@ -12,10 +12,12 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 import org.testcontainers.containers.Container;
 import org.testcontainers.containers.GenericContainer;
 
+@Profile("test")
 @Component
 public class PactMockServiceRegistry {
   private static final int MOCK_SERVICE_PORT = 80;

--- a/kahpp-spring-autoconfigure/src/test/java/dev/vox/platform/kahpp/test/instance/InstanceTestScenario.java
+++ b/kahpp-spring-autoconfigure/src/test/java/dev/vox/platform/kahpp/test/instance/InstanceTestScenario.java
@@ -1,3 +1,6 @@
 package dev.vox.platform.kahpp.test.instance;
 
+import org.springframework.test.context.ActiveProfiles;
+
+@ActiveProfiles("test")
 public class InstanceTestScenario extends InstanceTest {}

--- a/kahpp-spring-autoconfigure/src/test/java/dev/vox/platform/kahpp/test/instance/KahppSpringTestConfigurationTest.java
+++ b/kahpp-spring-autoconfigure/src/test/java/dev/vox/platform/kahpp/test/instance/KahppSpringTestConfigurationTest.java
@@ -5,7 +5,9 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.concurrent.ExecutorService;
 import org.junit.jupiter.api.Test;
+import org.springframework.test.context.ActiveProfiles;
 
+@ActiveProfiles("test")
 class KahppSpringTestConfigurationTest {
 
   @Test


### PR DESCRIPTION
Adding this new profile on these components will be excluded at startup time.

Reviewers: @GetFeedback/platform-java
