### PR TITLE
Update condition on publish action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,5 +1,10 @@
 name: publish
 on:
+  workflow_run:
+    workflows: [ check ]
+    branches: [ main ]
+    types:
+      - completed
   push:
     branches:
       - main
@@ -7,7 +12,6 @@ on:
       - /^\d+\.\d+\.\d+$/
 jobs:
   publish:
-    needs: [build]
     runs-on: ubuntu-20.04
     steps:
       - name: Publish artifact


### PR DESCRIPTION
Looks like is not possible to use a job as a dependency if it lives in another workflow, so we are adding a new condition on this workflow that runs only after the check action is completed.

Reviewers: @GetFeedback/platform-java
