### PR TITLE
Fix GitHub Actions

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,5 +1,8 @@
 name: check
-on: [push]
+on:
+  push:
+    branches:
+      - '**'
 jobs:
   build:
     runs-on: ubuntu-20.04

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,15 +4,14 @@ on:
     workflows: [ check ]
     types:
       - completed
-    branches:
-      - main
-  push:
-    branches:
-      - main
+  create:
     tags:
       - '[0-9]+.[0-9]+.[0-9]+$'
+    branches:
+      - 'main'
 jobs:
   publish:
+    if: startsWith(github.ref, 'refs/tags')
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout


### PR DESCRIPTION

The issue was that on 'push' check and publish are triggered together.
Use `create` instead of `push` for the publish action should avoid triggering this job on every push.

Reviewers: @GetFeedback/platform-java 