### PR TITLE
Update vulnerability task command execution

### DIFF
--- a/.github/workflows/dependency-check.yml
+++ b/.github/workflows/dependency-check.yml
@@ -22,9 +22,10 @@ jobs:
             --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED >> ./gradle.properties
       - name: Build report overview of the vulnerabilities per dependency
         run: |
-          ./gradlew dependencyCheckAnalyze
+          ./gradlew dependencyCheckAggregate
       - name: Upload dependency check report
         uses: actions/upload-artifact@v2
+        if: always()
         with:
-          name: dependency-check-report-${{ github.ref_name }}.html
+          name: dependency-check-report.html
           path: ./build/reports/dependency-check-report.html

--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,6 @@ subprojects {
     apply plugin: 'com.github.nbaztec.coveralls-jacoco'
     apply plugin: 'com.diffplug.spotless'
     apply plugin: 'signing'
-    apply plugin: 'org.owasp.dependencycheck'
 
     dependencyManagement {
         imports {


### PR DESCRIPTION
In this specific project is correct use `dependencyCheckAggregate` because is a multi module project.
With that old command we were executing the scan only for the root project.

Signed-off-by: Stefano Guerrini <sguerrini@surveymonkey.com>



Closes: GFPPLAT-
Reviewers: @GetFeedback/platform-java
