### PR TITLE
Fix RECORD_ROUTE to avoid forward

### DIFF
--- a/kahpp-spring-autoconfigure/src/main/java/dev/vox/platform/kahpp/configuration/http/ResponseHandlerRecordRoute.java
+++ b/kahpp-spring-autoconfigure/src/main/java/dev/vox/platform/kahpp/configuration/http/ResponseHandlerRecordRoute.java
@@ -25,7 +25,7 @@ public class ResponseHandlerRecordRoute implements ResponseHandler {
 
       @Override
       public boolean shouldForward() {
-        return true;
+        return false;
       }
     };
   }

--- a/kahpp-spring-autoconfigure/src/test/java/dev/vox/platform/kahpp/unit/configuration/http/ResponseHandlerTest.java
+++ b/kahpp-spring-autoconfigure/src/test/java/dev/vox/platform/kahpp/unit/configuration/http/ResponseHandlerTest.java
@@ -55,7 +55,7 @@ class ResponseHandlerTest {
     ResponseHandlerRecordRoute responseHandler =
         new ResponseHandlerRecordRoute(Collections.singleton(topic));
     RecordActionRoute handle = responseHandler.handle(this.response);
-    assertThat(handle.shouldForward()).isTrue();
+    assertThat(handle.shouldForward()).isFalse();
     assertThat(handle.routes()).contains(topic);
     assertThat(responseHandler.getTopics()).contains(topic);
   }


### PR DESCRIPTION
Once the record is routed to a specific topic the process of this record should terminate.
Set false on shouldForward of this Handler fix this issue.

Signed-off-by: Stefano Guerrini <sguerrini@surveymonkey.com>



Closes: GFPPLAT-
Reviewers: @GetFeedback/platform-java @dsantang @gfornari 
