### PR TITLE
Fix handle by status code on HTTP error

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ plugins {
 
 allprojects {
     group = 'dev.vox.platform.kahpp'
-    version = '0.0.1-SNAPSHOT'
+    version = '0.2.4-SNAPSHOT'
     if (project.hasProperty('projVersion')) {
         project.version = project.projVersion
     }

--- a/kahpp-spring-autoconfigure/src/main/java/dev/vox/platform/kahpp/configuration/http/AbstractHttpCall.java
+++ b/kahpp-spring-autoconfigure/src/main/java/dev/vox/platform/kahpp/configuration/http/AbstractHttpCall.java
@@ -4,7 +4,6 @@ import dev.vox.platform.kahpp.configuration.RecordAction;
 import dev.vox.platform.kahpp.configuration.conditional.Condition;
 import dev.vox.platform.kahpp.configuration.conditional.Conditional;
 import dev.vox.platform.kahpp.configuration.http.client.ApiClient;
-import dev.vox.platform.kahpp.configuration.http.client.exception.RequestException;
 import dev.vox.platform.kahpp.streams.KaHPPRecord;
 import io.vavr.control.Either;
 import io.vavr.control.Try;
@@ -76,15 +75,6 @@ public abstract class AbstractHttpCall implements HttpCall, Conditional {
 
     return Try.of(() -> apiClient.sendRequest(method, path, record.getValue().toString()))
         .mapTry(responseHandler::handle)
-        .recoverWith(
-            RequestException.class,
-            requestException -> {
-              if (responseHandler instanceof UnexpectedResponseHandler) {
-                return Try.of(
-                    () -> ((UnexpectedResponseHandler) responseHandler).handle(requestException));
-              }
-              return Try.failure(requestException);
-            })
         .toEither();
   }
 

--- a/kahpp-spring-autoconfigure/src/test/java/dev/vox/platform/kahpp/unit/configuration/http/ResponseHandlerRecordRouteTest.java
+++ b/kahpp-spring-autoconfigure/src/test/java/dev/vox/platform/kahpp/unit/configuration/http/ResponseHandlerRecordRouteTest.java
@@ -6,11 +6,11 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import dev.vox.platform.kahpp.configuration.RecordAction;
-import dev.vox.platform.kahpp.configuration.RecordActionRoute;
 import dev.vox.platform.kahpp.configuration.http.HandleByStatusCode;
 import dev.vox.platform.kahpp.configuration.http.HttpClient;
 import dev.vox.platform.kahpp.configuration.http.ResponseHandlerException;
 import dev.vox.platform.kahpp.configuration.http.ResponseHandlerRecordRoute;
+import dev.vox.platform.kahpp.configuration.http.client.exception.ClientException;
 import dev.vox.platform.kahpp.configuration.topic.TopicEntry;
 import dev.vox.platform.kahpp.configuration.util.Range;
 import dev.vox.platform.kahpp.integration.KaHPPMockServer;
@@ -78,9 +78,13 @@ class ResponseHandlerRecordRouteTest {
     Either<Throwable, RecordAction> afterCall =
         httpCall.call(KaHPPRecord.build(key, value, 1584352842123L));
 
-    assertTrue(afterCall.isRight());
-    assertThat(afterCall.get()).isInstanceOf(RecordActionRoute.class);
-    assertThat(((RecordActionRoute) afterCall.get()).routes()).contains(topic);
+    assertTrue(afterCall.isLeft());
+    assertThat(afterCall.getLeft()).isInstanceOf(ClientException.class);
+    assertThat(((ClientException) afterCall.getLeft()).getResponse().get().getStatusCode())
+        .isEqualTo(410);
+    assertThat(((ClientException) afterCall.getLeft()).getResponse().get().getBody())
+        .contains("""
+            {"foo":"bar"}""");
   }
 
   @Test


### PR DESCRIPTION
Handlers on Kahpp are implemented in a way that doesn't consent us from preserving the HTTP response in case of error easily.
On Kahpp, a standard HTTP step in case of error puts the HTTP response in the record's header and then routes the message on the error topic.
All Handlers work fine with this, except RECORD_ROUTE.
The goal of RECORD_ROUTE is to route a record based on the HTTP status code. If the status code is an error, we should preserve the response in the header, but we lost the response because we treated the error like a successful HTTP request, which is wrong.

For now, this fix helps to don't miss the HTTP response, so we'll have the errors in the header also for RECORD_ROUTE, like the default for other HTTP steps.
Anyway, this functionality (Handlers) needs to be refactored.

Reviewers: @GetFeedback/platform-java @dsantang @gfornari 
