### PR TITLE
Set spotbugs deps as compile only

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,8 @@ subprojects {
     }
 
     dependencies {
-        implementation("com.github.spotbugs:spotbugs-annotations:4.7.0")
+        compileOnly("com.github.spotbugs:spotbugs-annotations:4.7.0")
+        testCompileOnly("com.github.spotbugs:spotbugs-annotations:4.7.0")
         pmd("net.sourceforge.pmd:pmd-java:6.46.0") {
             exclude group: 'commons-io', module: 'commons-io'
         }

--- a/kahpp-spring-autoconfigure/build.gradle
+++ b/kahpp-spring-autoconfigure/build.gradle
@@ -10,7 +10,7 @@ configurations {
 }
 
 ext {
-    sentryVersion = '6.1.2'
+    sentryVersion = '6.1.0'
     micrometerVersion = '1.9.1'
     kafkaVersion = '3.1.0'
     logbackVersion = '1.2.11'
@@ -51,7 +51,6 @@ dependencies{
     implementation("ch.qos.logback:logback-classic:${logbackVersion}") {
         exclude group: "org.sl4j", module: "slf4j-api"
     }
-    implementation("com.github.spotbugs:spotbugs-annotations:4.7.0")
     implementation "org.apache.kafka:kafka-clients:${kafkaVersion}:test"
     implementation "org.apache.kafka:kafka_2.13:${kafkaVersion}"
     implementation "org.apache.kafka:kafka_2.13:${kafkaVersion}:test"


### PR DESCRIPTION
This dependency is unnecessary in the classpath;
Set as compileOnly and remove from subProject.

Reviewers: @GetFeedback/platform-java
