### PR TITLE
Update kahpp-spring-autoconfigure publication name 

### DIFF
--- a/kahpp-spring-autoconfigure/build.gradle
+++ b/kahpp-spring-autoconfigure/build.gradle
@@ -83,7 +83,7 @@ dependencies{
 
 publishing {
     publications {
-        starter(MavenPublication) {
+        autoconfigure(MavenPublication) {
             groupId = "${groupId}"
             artifactId = 'kahpp-spring-autoconfigure'
             version = "${version}"


### PR DESCRIPTION
A small update to the name given to publication, makes it all more clear.

Signed-off-by: Stefano Guerrini <sguerrini@surveymonkey.com>


Reviewers: @GetFeedback/platform-java
