### PR TITLE
Update dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,30 +9,6 @@ updates:
       - "Dependencies"
     reviewers:
       - "GetFeedback/platform-java"
-  - package-ecosystem: "gradle"
-    directory: "/kahpp-gradle-plugin"
-    schedule:
-      interval: "daily"
-    labels:
-      - "Dependencies"
-    reviewers:
-      - "GetFeedback/platform-java"
-  - package-ecosystem: "gradle"
-    directory: "/kahpp-spring-autoconfigure"
-    schedule:
-      interval: "daily"
-    labels:
-      - "Dependencies"
-    reviewers:
-      - "GetFeedback/platform-java"
-  - package-ecosystem: "gradle"
-    directory: "/kahpp-spring-starter"
-    schedule:
-      interval: "daily"
-    labels:
-      - "Dependencies"
-    reviewers:
-      - "GetFeedback/platform-java"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
This should resolve the duplication of PRs.
Since it's a multi module project dependabot should find all dependencies directly from the root project.

Signed-off-by: Stefano Guerrini <sguerrini@surveymonkey.com>


Reviewers: @GetFeedback/platform-java
