### PR TITLE
Fix helm to test drift detection

### DIFF
--- a/kahpp-gradle-plugin/src/main/groovy/dev/vox/platform/kahpp/gradle/plugin/KaHPPDetectHelmToTestDrift.groovy
+++ b/kahpp-gradle-plugin/src/main/groovy/dev/vox/platform/kahpp/gradle/plugin/KaHPPDetectHelmToTestDrift.groovy
@@ -32,7 +32,7 @@ abstract class KaHPPDetectHelmToTestDrift extends KaHPPHelmYamlAbstractTask {
                     .as("Instance '%s' was not tested", instanceName)
                     .isFile()
 
-            KaHPPInstance actualInstance = yaml.loadAs(actualInstanceFile.newDataInputStream(), KaHPPInstance.class)
+            Object actualInstance = yaml.load(actualInstanceFile.newDataInputStream());
             assertThat(yaml.dump(actualInstance))
                     .as("Instance '%s' has drifted from Helm", instanceName)
                     .isEqualTo(yaml.dump(expectedInstance))

--- a/kahpp-gradle-plugin/src/test/java/dev/vox/platform/kahpp/gradle/plugin/functional/HelmCopyTest.java
+++ b/kahpp-gradle-plugin/src/test/java/dev/vox/platform/kahpp/gradle/plugin/functional/HelmCopyTest.java
@@ -32,7 +32,7 @@ class HelmCopyTest {
   }
 
   @Test
-  void canDetectDriftFromHelmToTestsState() {
+  void canDetectUntestedInstanceDeclaredInHelmChart() {
     BuildResult result =
         GradleRunner.create()
             .withPluginClasspath()

--- a/kahpp-gradle-plugin/src/test/java/dev/vox/platform/kahpp/gradle/plugin/functional/HelmDriftTest.java
+++ b/kahpp-gradle-plugin/src/test/java/dev/vox/platform/kahpp/gradle/plugin/functional/HelmDriftTest.java
@@ -1,0 +1,86 @@
+package dev.vox.platform.kahpp.gradle.plugin.functional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import org.gradle.testkit.runner.BuildResult;
+import org.gradle.testkit.runner.BuildTask;
+import org.gradle.testkit.runner.GradleRunner;
+import org.gradle.testkit.runner.TaskOutcome;
+import org.junit.jupiter.api.Test;
+
+class HelmDriftTest {
+  @Test
+  void canDetectDriftBetweenHelmAndTestInstances() {
+    BuildResult result =
+        GradleRunner.create()
+            .withPluginClasspath()
+            .withProjectDir(getTestProjectDir("drift-detected"))
+            .withArguments("detectHelmToTestDrift")
+            .buildAndFail();
+
+    BuildTask taskResult = result.task(":detectHelmToTestDrift");
+    assertThat(taskResult).isNotNull();
+    assertThat(taskResult.getOutcome()).isEqualTo(TaskOutcome.FAILED);
+
+    assertThat(result.getOutput())
+        .contains(
+            "Found KaHPP configuration: 'kahpp-plugin-test-drift-detected-from-helm-to-test'",
+            "Instance 'kahpp-plugin-test-drift-detected-from-helm-to-test' has drifted from Helm",
+            """
+                expected:\s
+                    "kahpp:
+                      group: kahpp-plugin
+                      name: test-drift-detected-from-helm-to-test
+                      topics:
+                        source: my-source-topic
+                        sink: my-other-sink-topic
+                      streamsConfig:
+                        bootstrapServers:
+                        - kafka:9092
+                      steps:
+                      - name: myNewStep
+                        type: dev.vox.platform.kahpp.configuration.filter.FilterTombstone
+                        config:
+                          filterNot: true
+                      - name: produceRecordToSinkTopic
+                        type: dev.vox.platform.kahpp.configuration.topic.ProduceToTopic
+                        config:
+                          topic: sink
+                    "
+                   but was:\s
+                    "kahpp:
+                      group: kahpp-plugin
+                      name: test-drift-detected-from-helm-to-test
+                      topics:
+                        source: my-source-topic
+                        sink: my-sink-topic
+                      streamsConfig:
+                        bootstrapServers:
+                        - my-staging-cluster:9092
+                      steps:
+                      - name: produceRecordToSinkTopic
+                        type: dev.vox.platform.kahpp.configuration.topic.ProduceToTopic
+                        config:
+                          topic: sink
+                    \"""");
+  }
+
+  @Test
+  void passWhenThereIsNoDriftBetweenHelmAndTestInstances() {
+    BuildResult result =
+        GradleRunner.create()
+            .withPluginClasspath()
+            .withProjectDir(getTestProjectDir("no-drift"))
+            .withArguments("detectHelmToTestDrift")
+            .build();
+
+    BuildTask taskResult = result.task(":detectHelmToTestDrift");
+    assertThat(taskResult).isNotNull();
+    assertThat(taskResult.getOutcome()).isIn(TaskOutcome.SUCCESS, TaskOutcome.UP_TO_DATE);
+  }
+
+  private File getTestProjectDir(String scenario) {
+    return new File(ClassLoader.getSystemResource("functional/helm-drift/" + scenario).getFile());
+  }
+}

--- a/kahpp-gradle-plugin/src/test/resources/functional/helm-drift/drift-detected/build.gradle
+++ b/kahpp-gradle-plugin/src/test/resources/functional/helm-drift/drift-detected/build.gradle
@@ -1,0 +1,4 @@
+plugins {
+    id 'base'
+    id 'dev.vox.platform.kahpp'
+}

--- a/kahpp-gradle-plugin/src/test/resources/functional/helm-drift/drift-detected/helm/values/test/staging/values.yaml
+++ b/kahpp-gradle-plugin/src/test/resources/functional/helm-drift/drift-detected/helm/values/test/staging/values.yaml
@@ -1,0 +1,18 @@
+instance:
+  group: kahpp-plugin
+  name: test-drift-detected-from-helm-to-test
+  topics:
+    source: my-source-topic
+    sink: my-other-sink-topic
+  streamsConfig:
+    bootstrapServers:
+      - my-prod-cluster:9092
+  steps:
+    - name: myNewStep
+      type: dev.vox.platform.kahpp.configuration.filter.FilterTombstone
+      config:
+        filterNot: true
+    - name: produceRecordToSinkTopic
+      type: dev.vox.platform.kahpp.configuration.topic.ProduceToTopic
+      config:
+        topic: sink

--- a/kahpp-gradle-plugin/src/test/resources/functional/helm-drift/drift-detected/settings.gradle
+++ b/kahpp-gradle-plugin/src/test/resources/functional/helm-drift/drift-detected/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'functional-helm-drift'

--- a/kahpp-gradle-plugin/src/test/resources/functional/helm-drift/drift-detected/src/test/resources/functional/kahpp-plugin-test-drift-detected-from-helm-to-test/kahpp-instance.yaml
+++ b/kahpp-gradle-plugin/src/test/resources/functional/helm-drift/drift-detected/src/test/resources/functional/kahpp-plugin-test-drift-detected-from-helm-to-test/kahpp-instance.yaml
@@ -1,0 +1,14 @@
+kahpp:
+  group: kahpp-plugin
+  name: test-drift-detected-from-helm-to-test
+  topics:
+    source: my-source-topic
+    sink: my-sink-topic
+  streamsConfig:
+    bootstrapServers:
+      - my-staging-cluster:9092
+  steps:
+    - name: produceRecordToSinkTopic
+      type: dev.vox.platform.kahpp.configuration.topic.ProduceToTopic
+      config:
+        topic: sink

--- a/kahpp-gradle-plugin/src/test/resources/functional/helm-drift/no-drift/build.gradle
+++ b/kahpp-gradle-plugin/src/test/resources/functional/helm-drift/no-drift/build.gradle
@@ -1,0 +1,4 @@
+plugins {
+    id 'base'
+    id 'dev.vox.platform.kahpp'
+}

--- a/kahpp-gradle-plugin/src/test/resources/functional/helm-drift/no-drift/helm/values/test/staging/values.yaml
+++ b/kahpp-gradle-plugin/src/test/resources/functional/helm-drift/no-drift/helm/values/test/staging/values.yaml
@@ -1,0 +1,18 @@
+instance:
+  group: kahpp-plugin
+  name: test-no-drift-detected-from-helm-to-test
+  topics:
+    source: my-source-topic
+    sink: my-other-sink-topic
+  streamsConfig:
+    bootstrapServers:
+      - my-prod-cluster:9092
+  steps:
+    - name: myNewStep
+      type: dev.vox.platform.kahpp.configuration.filter.FilterTombstone
+      config:
+        filterNot: true
+    - name: produceRecordToSinkTopic
+      type: dev.vox.platform.kahpp.configuration.topic.ProduceToTopic
+      config:
+        topic: sink

--- a/kahpp-gradle-plugin/src/test/resources/functional/helm-drift/no-drift/settings.gradle
+++ b/kahpp-gradle-plugin/src/test/resources/functional/helm-drift/no-drift/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'functional-helm-drift'

--- a/kahpp-gradle-plugin/src/test/resources/functional/helm-drift/no-drift/src/test/resources/functional/kahpp-plugin-test-no-drift-detected-from-helm-to-test/kahpp-instance.yaml
+++ b/kahpp-gradle-plugin/src/test/resources/functional/helm-drift/no-drift/src/test/resources/functional/kahpp-plugin-test-no-drift-detected-from-helm-to-test/kahpp-instance.yaml
@@ -1,0 +1,18 @@
+kahpp:
+  group: kahpp-plugin
+  name: test-no-drift-detected-from-helm-to-test
+  topics:
+    source: my-source-topic
+    sink: my-other-sink-topic
+  streamsConfig:
+    bootstrapServers:
+      - kafka:9092
+  steps:
+    - name: myNewStep
+      type: dev.vox.platform.kahpp.configuration.filter.FilterTombstone
+      config:
+        filterNot: true
+    - name: produceRecordToSinkTopic
+      type: dev.vox.platform.kahpp.configuration.topic.ProduceToTopic
+      config:
+        topic: sink


### PR DESCRIPTION
The `snakeyaml` package used to detect drifts between KaHPP instance configurations declared in Helm charts and tests introduced some changes in [version 1.31](https://bitbucket.org/snakeyaml/snakeyaml/commits/tag/snakeyaml-1.31) that broke the corresponding Gradle task.

[commit e9e0094](https://bitbucket.org/snakeyaml/snakeyaml/commits/e9e009441956f981b593c70cad912186d29a3a6b) changes the way in which new Objects are created for YAML nodes - removing the handling of `InstantiationException`. Turns out that our task relied on that bit of code!

Instead of attempting to read the test KaHPP instance configuration YAML files in as `KaHPPInstance` objects, we now simply load them as `Object`s. The comparison of the resulting YAML structure remains the same.

In order to detect similar future breaking changes in our dependencies, tests cases have been added for KaHPP instance configuration drift detection.


Reviewers: @GetFeedback/platform-java
