### PR TITLE
Rename metric prefix

### DIFF
--- a/kahpp-spring-autoconfigure/src/main/java/dev/vox/platform/kahpp/step/StepMetricUtils.java
+++ b/kahpp-spring-autoconfigure/src/main/java/dev/vox/platform/kahpp/step/StepMetricUtils.java
@@ -8,7 +8,7 @@ import java.util.List;
 
 public class StepMetricUtils {
 
-  private static final String KAHPP_METRIC_PREFIX = "kahppMetricPrefix";
+  private static final String KAHPP_METRIC_PREFIX = "kahpp";
   private static final String METRIC_TAG_STEP_CLASS = "step";
   private static final String METRIC_TAG_STEP_NAME = "step_name";
 

--- a/kahpp-spring-autoconfigure/src/test/java/dev/vox/platform/kahpp/integration/filter/FilterNotTest.java
+++ b/kahpp-spring-autoconfigure/src/test/java/dev/vox/platform/kahpp/integration/filter/FilterNotTest.java
@@ -63,7 +63,7 @@ class FilterNotTest extends AbstractKaHPPTest {
     assertThat(actual)
         .isEqualTo(
             meterRegistry
-                .get("kahppMetricPrefix.filter")
+                .get("kahpp.filter")
                 .tag("step", "FilterValue")
                 .tag("step_name", "keepUnsupportedProducts")
                 .tag("forwarded", Boolean.toString(forwarded))

--- a/kahpp-spring-autoconfigure/src/test/java/dev/vox/platform/kahpp/integration/filter/FilterTest.java
+++ b/kahpp-spring-autoconfigure/src/test/java/dev/vox/platform/kahpp/integration/filter/FilterTest.java
@@ -42,7 +42,7 @@ class FilterTest extends AbstractKaHPPTest {
     assertThat(actual)
         .isEqualTo(
             meterRegistry
-                .get("kahppMetricPrefix.filter")
+                .get("kahpp.filter")
                 .tag("step", "FilterValue")
                 .tag("step_name", "getSupportedProducts")
                 .tag("forwarded", Boolean.toString(forwarded))

--- a/kahpp-spring-autoconfigure/src/test/java/dev/vox/platform/kahpp/integration/filter/FilterTombstoneTest.java
+++ b/kahpp-spring-autoconfigure/src/test/java/dev/vox/platform/kahpp/integration/filter/FilterTombstoneTest.java
@@ -70,7 +70,7 @@ class FilterTombstoneTest extends AbstractKaHPPTest {
   private void assertFilterTombstoneMetric(double expected, boolean forwarded) {
     assertThat(
             meterRegistry
-                .get("kahppMetricPrefix.filter")
+                .get("kahpp.filter")
                 .tag("step", "FilterTombstone")
                 .tag("step_name", "dropTombstoneRecords")
                 .tag("forwarded", Boolean.toString(forwarded))

--- a/kahpp-spring-autoconfigure/src/test/java/dev/vox/platform/kahpp/integration/http/HttpMetricsTest.java
+++ b/kahpp-spring-autoconfigure/src/test/java/dev/vox/platform/kahpp/integration/http/HttpMetricsTest.java
@@ -80,7 +80,7 @@ class HttpMetricsTest extends AbstractKaHPPTest {
   private void assertTimeMetric(boolean successful, long expected) {
     assertThat(
             meterRegistry
-                .get("kahppMetricPrefix.http.duration")
+                .get("kahpp.http.duration")
                 .tag("step", "OkOrProduceError")
                 .tag("step_name", "doAnAPICall")
                 .tag("successful", Boolean.toString(successful))
@@ -92,7 +92,7 @@ class HttpMetricsTest extends AbstractKaHPPTest {
   private void assertStepMetricsCount(double expected, boolean successful) {
     assertThat(
             meterRegistry
-                .get("kahppMetricPrefix.http.status")
+                .get("kahpp.http.status")
                 .tag("step", "OkOrProduceError")
                 .tag("step_name", "doAnAPICall")
                 .tag("successful", Boolean.toString(successful))

--- a/kahpp-spring-autoconfigure/src/test/java/dev/vox/platform/kahpp/integration/meter/MeterTest.java
+++ b/kahpp-spring-autoconfigure/src/test/java/dev/vox/platform/kahpp/integration/meter/MeterTest.java
@@ -13,8 +13,7 @@ import org.springframework.kafka.test.utils.KafkaTestUtils;
 
 final class MeterTest extends AbstractKaHPPTest {
 
-  private static final String METRIC_COLLECTION_PER_CHANNEL =
-      "kahppMetricPrefix.collectionPerChannel";
+  private static final String METRIC_COLLECTION_PER_CHANNEL = "kahpp.collectionPerChannel";
 
   @Autowired private transient MeterRegistry meterRegistry;
 

--- a/kahpp-spring-autoconfigure/src/test/java/dev/vox/platform/kahpp/unit/configuration/http/HttpCallStepProcessorRecordActionTest.java
+++ b/kahpp-spring-autoconfigure/src/test/java/dev/vox/platform/kahpp/unit/configuration/http/HttpCallStepProcessorRecordActionTest.java
@@ -84,7 +84,7 @@ class HttpCallStepProcessorRecordActionTest {
 
   private Double getProduceCountOnTopic(String topic) {
     return meterRegistry
-        .get("kahppMetricPrefix.produce")
+        .get("kahpp.produce")
         .tag("step_name", STEP_NAME)
         .tag("topic", topic)
         .counter()

--- a/kahpp-spring-autoconfigure/src/test/java/dev/vox/platform/kahpp/unit/configuration/http/HttpCallStepProcessorTest.java
+++ b/kahpp-spring-autoconfigure/src/test/java/dev/vox/platform/kahpp/unit/configuration/http/HttpCallStepProcessorTest.java
@@ -152,7 +152,7 @@ class HttpCallStepProcessorTest {
 
   private Timer getTimerMetric(boolean successful) {
     return meterRegistry
-        .get("kahppMetricPrefix.http.duration")
+        .get("kahpp.http.duration")
         .tag("step", HTTP_STEP_CLASS)
         .tag("step_name", HTTP_STEP_NAME)
         .tag("successful", Boolean.toString(successful))
@@ -161,7 +161,7 @@ class HttpCallStepProcessorTest {
 
   private DistributionSummary getDistributionSummary() {
     return meterRegistry
-        .get("kahppMetricPrefix.http.response_time_ms")
+        .get("kahpp.http.response_time_ms")
         .tag("step", HTTP_STEP_CLASS)
         .tag("step_name", HTTP_STEP_NAME)
         .tag("successful", Boolean.toString(true))
@@ -182,7 +182,7 @@ class HttpCallStepProcessorTest {
   private void assertCountStatus(double expected, boolean successful) {
     assertThat(
             meterRegistry
-                .get("kahppMetricPrefix.http.status")
+                .get("kahpp.http.status")
                 .tag("step", HTTP_STEP_CLASS)
                 .tag("step_name", HTTP_STEP_NAME)
                 .tag("successful", Boolean.toString(successful))

--- a/kahpp-spring-autoconfigure/src/test/java/dev/vox/platform/kahpp/unit/processor/StepProcessorTest.java
+++ b/kahpp-spring-autoconfigure/src/test/java/dev/vox/platform/kahpp/unit/processor/StepProcessorTest.java
@@ -87,7 +87,7 @@ class StepProcessorTest {
   private void assertCountForward(int expected, boolean forwarded) {
     assertThat(
             meterRegistry
-                .get("kahppMetricPrefix.forward")
+                .get("kahpp.forward")
                 .tag(STEP_NAME, "SimpleStep")
                 .tag("step_name", STEP_NAME)
                 .tag("forwarded", Boolean.toString(forwarded))
@@ -133,7 +133,7 @@ class StepProcessorTest {
   private void assertCountProduce(int expected) {
     assertThat(
             meterRegistry
-                .get("kahppMetricPrefix.produce")
+                .get("kahpp.produce")
                 .tag(STEP_NAME, "SimpleProduceStep")
                 .tag("step_name", STEP_NAME)
                 .tag("topic", "mock")
@@ -206,7 +206,7 @@ class StepProcessorTest {
   private void assertCountConditional(int expected) {
     assertThat(
             meterRegistry
-                .get("kahppMetricPrefix.conditional_skip")
+                .get("kahpp.conditional_skip")
                 .tag(STEP_NAME, "SimpleConditional")
                 .tag("step_name", STEP_NAME)
                 .counters()

--- a/kahpp-spring-autoconfigure/src/test/java/dev/vox/platform/kahpp/unit/step/StepMetricUtilsTest.java
+++ b/kahpp-spring-autoconfigure/src/test/java/dev/vox/platform/kahpp/unit/step/StepMetricUtilsTest.java
@@ -63,16 +63,14 @@ class StepMetricUtilsTest {
 
   @Test
   void formatMetricName() {
-    assertThat(StepMetricUtils.formatMetricName("awesome")).isEqualTo("kahppMetricPrefix.awesome");
+    assertThat(StepMetricUtils.formatMetricName("awesome")).isEqualTo("kahpp.awesome");
 
-    assertThat(StepMetricUtils.formatMetricName(httpCall)).isEqualTo("kahppMetricPrefix.http");
-    assertThat(StepMetricUtils.formatMetricName(predicateBranch))
-        .isEqualTo("kahppMetricPrefix.filter");
+    assertThat(StepMetricUtils.formatMetricName(httpCall)).isEqualTo("kahpp.http");
+    assertThat(StepMetricUtils.formatMetricName(predicateBranch)).isEqualTo("kahpp.filter");
 
-    assertThat(StepMetricUtils.formatMetricName(httpCall, "last"))
-        .isEqualTo("kahppMetricPrefix.http.last");
+    assertThat(StepMetricUtils.formatMetricName(httpCall, "last")).isEqualTo("kahpp.http.last");
     assertThat(StepMetricUtils.formatMetricName(predicateBranch, "last"))
-        .isEqualTo("kahppMetricPrefix.filter.last");
+        .isEqualTo("kahpp.filter.last");
 
     assertThatThrownBy(() -> StepMetricUtils.formatMetricName(() -> "notMapped"))
         .isInstanceOf(RuntimeException.class);


### PR DESCRIPTION
After the introduction of 'micrometer-prometheus' the exported metrics changed in the name. So, for all Kahpp custom metrics, the prefix was 'kahppMetricPrefix' then the JMX exporter was mapping these to 'kahpp_*'. Now that we use 'micrometer' we don't need to use JMX exporter, for this reason, the prefix will become 'kahpp'.

Signed-off-by: Stefano Guerrini <sguerrini@surveymonkey.com>


Reviewers: @GetFeedback/platform-java @cvmiert 
